### PR TITLE
feat: display profile name in navbar if available

### DIFF
--- a/src/containers/LearnerDashboardHeader/ExpandedHeader/AuthenticatedUserDropdown.jsx
+++ b/src/containers/LearnerDashboardHeader/ExpandedHeader/AuthenticatedUserDropdown.jsx
@@ -25,7 +25,7 @@ export const AuthenticatedUserDropdown = () => {
           className="p-4"
         >
           <span data-hj-suppress className="d-md-inline">
-            {authenticatedUser.username}
+            {authenticatedUser.name || authenticatedUser.username}
           </span>
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">


### PR DESCRIPTION
## Description

Display profile name in navbar if available.

Port of https://github.com/open-craft/frontend-app-learner-dashboard/commit/157056e91789eabe2b9fcd2f5ee76a1190b0c4da to Redwood.

## Testing instructions

1. Set a user's first and last name in Django Admin UI (**not** in user profile settings).
2. See full name instead of username in header.

![image](https://github.com/user-attachments/assets/274ac4f3-8de1-49f5-b671-e0734f536bbe)

## Deadline

2024-07-22

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-8994