### PR TITLE
[BB-9429] fix: course image height on IOS Safari

### DIFF
--- a/src/containers/CourseCard/CourseCard.scss
+++ b/src/containers/CourseCard/CourseCard.scss
@@ -8,6 +8,7 @@
     }
     .pgn__card-image-cap {
       border-bottom-left-radius: 0 !important;
+      height: auto !important;
     }
     .overflow-visible {
       overflow: visible;


### PR DESCRIPTION
Backport of: https://github.com/openedx/frontend-app-learner-dashboard/pull/553

### Description

Course thumbnails on IOS Safari stretch to the full height of the image, instead of being limited by width and preserving aspect ratio. This seems to be a IOS Safari specific behavior[1], and can be fixed by setting height to auto, while width is set to 100%.

This issues is specific to the context of the course card, so we are fixing it by setting the height in the course card css, instead of fixing it globally in the Paragon styles, which wouldn't work in all contexts.

1: https://stackoverflow.com/a/44250830

### Screenshots

Screenshots taken from an iPhone of the same course on the course dashboard before and after the fix. Course name censored for privacy.

<details> 
  <summary>Before</summary>
  <img src="https://github.com/user-attachments/assets/f6a942c6-be96-48d1-ae77-7b1fe8fd48f6">
</details>
<details> 
  <summary>After</summary>
  <img src="https://github.com/user-attachments/assets/802032a7-213d-4c40-8edf-a05683d3f1fc">
</details>
